### PR TITLE
Add NetBird staging app with local-auth setup

### DIFF
--- a/apps/staging/netbird/kustomization.yaml
+++ b/apps/staging/netbird/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: netbird
+resources:
+  - namespace.yaml
+  - repository.yaml
+  - netbird-secret.yaml
+  - release.yaml
+  - virtual-service.yaml

--- a/apps/staging/netbird/namespace.yaml
+++ b/apps/staging/netbird/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: netbird

--- a/apps/staging/netbird/netbird-secret.yaml
+++ b/apps/staging/netbird/netbird-secret.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: netbird
+    namespace: netbird
+type: Opaque
+stringData:
+    relayPassword: ENC[AES256_GCM,data:BTGn5nCYSf879irWYihI0YBCNIAmwJRycZWy8YyY7v+fEv+iCI+1E7UhyuE=,iv:gtR3XyqtsABpI48zz3U3OV7Bm8lm4CRyKhDFj7Vu6OA=,tag:nAqkQK5KWicI6q/fRTqBoA==,type:str]
+    datastoreEncryptionKey: ENC[AES256_GCM,data:VbTT3XqYLTO4BRjvnKXiU8AMtpCzopyeaBlNsqRMHqJxG3u5DcKbnvpNHWk=,iv:C1Yad6Im5CMkCZTI70JQLJ6VeGCCMlFvfVgcD/hlR1c=,tag:WlHJ8V6igtvCglIETVuZtQ==,type:str]
+    encryptionKey: ENC[AES256_GCM,data:vWLVL5TWa/vV20uRp/YFYBrwAuESr5Ob4RVfBh+iDGDVgeEL31QBbOQY/r0=,iv:QMVUe9/tWYdTobkKfC4BBvOG/9kSqPhT9jNMOX/T8cg=,tag:NAUF/3ezFGSdIridVWtPqw==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2026-04-20T22:11:44Z"
+    mac: ENC[AES256_GCM,data:jUxmYAGAyuNNMKrsZti+HGh08TKzbdXR09ieQKAi45xvwmoGIRn/eqZVQgLS52ffXzYPapqc0PMKaF4mCzEv4HhQWz27eVMXGP8wCUfF0HE+o9RKOaz4Lmh+sbcVcFo19UbXEfD2wCWWZabaCnVJos9XOhIPyGFtxsZBZYRH8zE=,iv:/75/Z5PngeAuNrVsGcKBMlagRIuHdg7Iwy53VfbR/KU=,tag:YENUOLlwph7y1DV0zhtr8w==,type:str]
+    pgp:
+        - created_at: "2026-04-20T22:11:44Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAysLiv07AHPqAQ//QBUCJfwHqcA1TAvigBKEX8FlNitYEYqvoRdE8kI+7oFf
+            40GZ0mwy6ILJQGol+H2t62EGtbuJPDFcQPJdJbedItAbHq2lZ8HwgQSub/Dan74j
+            Zr/6ad+gOLK8uIXsxnAo1w7YBfJl0fLVfPE8Jg5E5b2Hk385eELqOEKMcrAbw095
+            cEwTM2VPHvzLDg8hhxlsX7ASOLaeO0iEEDO0lbBY51vTV5SootcFACpOrXmI1V33
+            ectH7+XeSxSPm4OMI56Vbd6mgxHQvHQaTKdQj4EADX/44gmabZGuk1KbaOi/K76S
+            CYk7xo/DBi6K98vG+aBuJjcOe0OxTltds3VLp1E9OwW36Vo8x4gWSIQEOUieS+Qr
+            jFn9RK0fDofKLIRuTAv+jdMpPOboV8575xR6QhnXHPpfiudNbS0mc+RD7Bcliqff
+            vkzdGwV0NZyPMSCloRU8OuPiddysYUqmDcsZ9PW28z5CqKFElI7DDGWCH/8zZfTa
+            8zW5zv9Uk7I6Oie9OIM6VVqbyVui2rRoDyTk7bvM+2q/O3KYz0BGQbmAmX3Kh7/e
+            iCggq+vdO6cpnYiaFw8sO6LXG4geZZbTCQO6zqvkrCuobNpy5Vwean0LyifNIv3W
+            U5dOS/79Dj5mj65pnrCiMkaVg6OQE73jekisurxFX97OEfOyLHDH8D0/s5AXyjfU
+            aAEJAhCBUQ92cWJm9l9Xh6bczxx4GTmNJJk5AbqJWIaG2OYPKNCI4LAOBFpVkLZP
+            gGhsQF+HtnPr7pp2h0aOWbAG2OEI4mNjpQvAZQcOPF2YxrTGDHW5bSCbu/SNba5M
+            X+b074FQ0Kv4
+            =0wVC
+            -----END PGP MESSAGE-----
+          fp: 427B2D23D5B5520342F0FE825DDB497AADABDF0E
+    encrypted_regex: ^(data|stringData)$
+    version: 3.8.1

--- a/apps/staging/netbird/release.yaml
+++ b/apps/staging/netbird/release.yaml
@@ -34,6 +34,7 @@ spec:
           - --disable-anonymous-metrics=false
           - --single-account-mode-domain=marianobe.cc
           - --dns-domain=netbird.marianobe.cc
+          - --config=/etc/netbird/management.json
       persistentVolume:
         enabled: true
         size: 5Gi
@@ -64,13 +65,13 @@ spec:
           "TURNConfig": {
             "TimeBasedCredentials": false,
             "CredentialsTTL": "12h0m0s",
-            "Secret": "secret",
+            "Secret": "${RELAY_PASSWORD}",
             "Turns": []
           },
           "Relay": {
             "Addresses": ["rels://netbird.marianobe.cc:443/relay"],
             "CredentialsTTL": "24h",
-            "Secret": "{{ .RELAY_PASSWORD }}"
+            "Secret": "${RELAY_PASSWORD}"
           },
           "Signal": {
             "Proto": "https",
@@ -79,7 +80,8 @@ spec:
             "Password": ""
           },
           "Datadir": "/var/lib/netbird/",
-          "DataStoreEncryptionKey": "{{ .DATASTORE_ENCRYPTION_KEY }}",
+          "EncryptionKey": "${NETBIRD_ENCRYPTION_KEY}",
+          "DataStoreEncryptionKey": "${DATASTORE_ENCRYPTION_KEY}",
           "HttpConfig": {
             "AuthIssuer": "https://netbird.marianobe.cc/oauth2",
             "AuthAudience": "netbird-dashboard",

--- a/apps/staging/netbird/release.yaml
+++ b/apps/staging/netbird/release.yaml
@@ -1,0 +1,155 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: netbird
+  namespace: netbird
+spec:
+  interval: 30m
+  releaseName: netbird
+  targetNamespace: netbird
+  chart:
+    spec:
+      chart: netbird
+      version: "1.9.0"
+      sourceRef:
+        kind: HelmRepository
+        name: netbird
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: netbird
+
+    management:
+      image:
+        tag: v0.69.0
+      podCommand:
+        args:
+          - --port=80
+          - --log-file=console
+          - --log-level=info
+          - --disable-anonymous-metrics=false
+          - --single-account-mode-domain=marianobe.cc
+          - --dns-domain=netbird.marianobe.cc
+      persistentVolume:
+        enabled: true
+        size: 5Gi
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+      env:
+        NETBIRD_EMBEDDED_IDP_ENABLED: "true"
+        NETBIRD_EMBEDDED_IDP_DATA_DIR: /var/lib/netbird/idp
+      envFromSecret:
+        RELAY_PASSWORD: netbird/relayPassword
+        DATASTORE_ENCRYPTION_KEY: netbird/datastoreEncryptionKey
+        NETBIRD_ENCRYPTION_KEY: netbird/encryptionKey
+      configmap: |-
+        {
+          "Stuns": [
+            {
+              "Proto": "udp",
+              "URI": "stun:stun.l.google.com:19302",
+              "Username": "",
+              "Password": ""
+            }
+          ],
+          "TURNConfig": {
+            "TimeBasedCredentials": false,
+            "CredentialsTTL": "12h0m0s",
+            "Secret": "secret",
+            "Turns": []
+          },
+          "Relay": {
+            "Addresses": ["rels://netbird.marianobe.cc:443/relay"],
+            "CredentialsTTL": "24h",
+            "Secret": "{{ .RELAY_PASSWORD }}"
+          },
+          "Signal": {
+            "Proto": "https",
+            "URI": "netbird.marianobe.cc:443",
+            "Username": "",
+            "Password": ""
+          },
+          "Datadir": "/var/lib/netbird/",
+          "DataStoreEncryptionKey": "{{ .DATASTORE_ENCRYPTION_KEY }}",
+          "HttpConfig": {
+            "AuthIssuer": "https://netbird.marianobe.cc/oauth2",
+            "AuthAudience": "netbird-dashboard",
+            "OIDCConfigEndpoint": "https://netbird.marianobe.cc/oauth2/.well-known/openid-configuration",
+            "AuthKeysLocation": "https://netbird.marianobe.cc/oauth2/keys",
+            "AuthUserIDClaim": "sub",
+            "IdpSignKeyRefreshEnabled": true
+          },
+          "StoreConfig": {
+            "Engine": "sqlite"
+          },
+          "EmbeddedIdP": {
+            "Enabled": true,
+            "DataDir": "/var/lib/netbird/idp"
+          },
+          "ReverseProxy": {
+            "TrustedHTTPProxies": null,
+            "TrustedHTTPProxiesCount": 0,
+            "TrustedPeers": null
+          }
+        }
+
+    signal:
+      image:
+        tag: v0.69.0
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+
+    relay:
+      image:
+        tag: v0.69.0
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+      envFromSecret:
+        NB_AUTH_SECRET: netbird/relayPassword
+      env:
+        NB_LOG_LEVEL: info
+        NB_LISTEN_ADDRESS: ":33080"
+        NB_EXPOSED_ADDRESS: rels://netbird.marianobe.cc:443/relay
+
+    dashboard:
+      image:
+        tag: v2.36.0
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 250m
+          memory: 256Mi
+      env:
+        NETBIRD_MGMT_API_ENDPOINT: https://netbird.marianobe.cc
+        NETBIRD_MGMT_GRPC_API_ENDPOINT: https://netbird.marianobe.cc
+        AUTH_AUDIENCE: netbird-dashboard
+        AUTH_CLIENT_ID: netbird-dashboard
+        AUTH_CLIENT_SECRET: ""
+        AUTH_AUTHORITY: https://netbird.marianobe.cc/oauth2
+        USE_AUTH0: false
+        AUTH_SUPPORTED_SCOPES: openid profile email groups
+        AUTH_REDIRECT_URI: /nb-auth
+        AUTH_SILENT_REDIRECT_URI: /nb-silent-auth
+        NETBIRD_TOKEN_SOURCE: accessToken
+        NGINX_SSL_PORT: 443

--- a/apps/staging/netbird/repository.yaml
+++ b/apps/staging/netbird/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: netbird
+  namespace: netbird
+spec:
+  interval: 24h
+  url: https://netbirdio.github.io/helms

--- a/apps/staging/netbird/virtual-service.yaml
+++ b/apps/staging/netbird/virtual-service.yaml
@@ -1,0 +1,80 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: netbird
+  namespace: netbird
+spec:
+  gateways:
+    - istio-ingress/istio-gw
+  hosts:
+    - netbird.marianobe.cc
+  http:
+    - match:
+        - uri:
+            prefix: /
+          scheme:
+            exact: http
+      redirect:
+        scheme: https
+        redirectCode: 302
+    - match:
+        - uri:
+            prefix: /api
+      route:
+        - destination:
+            host: netbird-management.netbird.svc.cluster.local
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /oauth2
+      route:
+        - destination:
+            host: netbird-management.netbird.svc.cluster.local
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /management.ManagementService
+      route:
+        - destination:
+            host: netbird-management.netbird.svc.cluster.local
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /ws-proxy/management
+      route:
+        - destination:
+            host: netbird-management.netbird.svc.cluster.local
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /signalexchange.SignalExchange
+      route:
+        - destination:
+            host: netbird-signal.netbird.svc.cluster.local
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /ws-proxy/signal
+      route:
+        - destination:
+            host: netbird-signal.netbird.svc.cluster.local
+            port:
+              number: 80
+    - match:
+        - uri:
+            prefix: /relay
+      route:
+        - destination:
+            host: netbird-relay.netbird.svc.cluster.local
+            port:
+              number: 33080
+    - route:
+        - destination:
+            host: netbird-dashboard.netbird.svc.cluster.local
+            port:
+              number: 80

--- a/infrastructure/addons/istio/gateway.yaml
+++ b/infrastructure/addons/istio/gateway.yaml
@@ -13,6 +13,7 @@ spec:
       - k3s.marianobe.cc
       - marianobe.cc
       - www.marianobe.cc
+      - netbird.marianobe.cc
     # This was replaced by a more specific redirect in each VirtualService
     # tls:
       # httpsRedirect: true
@@ -24,6 +25,7 @@ spec:
       - k3s.marianobe.cc
       - marianobe.cc
       - www.marianobe.cc
+      - netbird.marianobe.cc
     tls:
       mode: SIMPLE
       credentialName: k3s-ingress-cert-0
@@ -45,6 +47,7 @@ spec:
   - k3s.marianobe.cc
   - marianobe.cc
   - www.marianobe.cc
+  - netbird.marianobe.cc
   issuerRef:
     name: letsencrypt
     kind: ClusterIssuer


### PR DESCRIPTION
## Summary
- Add a new Flux-managed NetBird app under `apps/staging/netbird` using the official `netbirdio/netbird` Helm chart.
- Configure NetBird for embedded local users, encrypted SOPS secrets, and Istio virtual service routing for dashboard, API, signal, and relay paths.
- Extend the Istio gateway certificate/hosts to include `netbird.marianobe.cc` so TLS and host routing work with the existing ingress.

## Validation
- Ran `kubectl apply --dry-run=client -k apps/staging/netbird` successfully.
- Ran `kubectl apply --dry-run=server -k apps/staging/netbird`; expected failures occurred for SOPS-encrypted secret and namespace creation ordering in dry-run mode.
- Ran `kubectl kustomize apps/staging/netbird` and `kubectl kustomize infrastructure/addons/istio` successfully.