### PR TITLE
Fix NetBird image tags and management config

### DIFF
--- a/apps/staging/netbird/release.yaml
+++ b/apps/staging/netbird/release.yaml
@@ -25,7 +25,7 @@ spec:
 
     management:
       image:
-        tag: v0.69.0
+        tag: 0.69.0
       podCommand:
         args:
           - --port=80
@@ -106,7 +106,7 @@ spec:
 
     signal:
       image:
-        tag: v0.69.0
+        tag: 0.69.0
       resources:
         requests:
           cpu: 50m
@@ -117,7 +117,7 @@ spec:
 
     relay:
       image:
-        tag: v0.69.0
+        tag: 0.69.0
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Summary
- Fix image tags: use `0.69.0` without `v` prefix (NetBird images don't use `v` prefix)
- Add missing `--config=/etc/netbird/management.json` flag to management args
- Switch configmap templating from `{{ .VAR }}` to `${VAR}` (NetBird env expansion syntax)
- Add missing `EncryptionKey` field and secure `TURNConfig.Secret` with env var

Follow-up to #2 (which merged without these fixes).